### PR TITLE
Hw11

### DIFF
--- a/react-chat/src/components/Avatar/Avatar.jsx
+++ b/react-chat/src/components/Avatar/Avatar.jsx
@@ -1,13 +1,14 @@
 import classes from './Avatar.module.scss';
 import React from "react";
 import {imgOrPlaceholder} from "../../utils/imgOrPlaceholder/imgOrPlaceholder.js";
+import LazyImage from "../LazyImage/LazyImage.jsx";
 
 export const Avatar = ({src}) => {
 
     const handledSrc = imgOrPlaceholder(src);
     return (
         <div className={classes.AvatarContainer}>
-            <img src={handledSrc} alt={"avatar"} className={classes.AvatarImage}/>
+            <LazyImage src={handledSrc} alt={"avatar"} className={classes.AvatarImage}/>
         </div>
     )
 }

--- a/react-chat/src/components/ChatItem/ChatPhoto.jsx
+++ b/react-chat/src/components/ChatItem/ChatPhoto.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import styles from './ChatItem.module.scss'
 import {imgOrPlaceholder} from "../../utils/imgOrPlaceholder/imgOrPlaceholder.js";
+import LazyImage from "../LazyImage/LazyImage.jsx";
 
 export const ChatPhoto = ({ person }) => {
     const src = imgOrPlaceholder(person.avatar);
     return (
         <div className={styles.chatItemPhoto}>
-            <img src={src} alt={person.name}/>
+            <LazyImage src={src} alt={person.name}/>
         </div>
     );
 };

--- a/react-chat/src/components/EditableFields/ProfilePhoto/ProfilePhoto.jsx
+++ b/react-chat/src/components/EditableFields/ProfilePhoto/ProfilePhoto.jsx
@@ -62,7 +62,7 @@ export const ProfilePhoto = ({ person, setPerson }) => {
                 onClick={() => fileInputRef.current.click()}
             >
                 <div className={styles.ProfilePhotoContainer}>
-                    <LazyImage src={imageSrc} alt="Profile Preview" />
+                    <LazyImage src={imageSrc} alt="Profile Preview" className={styles.ProfilePhotoPreviewImg}/>
                     <div
                         className={`${styles.ProfilePhotoContainerChange} ${styles.slideInBottom}`}
                     >

--- a/react-chat/src/components/EditableFields/ProfilePhoto/ProfilePhoto.jsx
+++ b/react-chat/src/components/EditableFields/ProfilePhoto/ProfilePhoto.jsx
@@ -1,6 +1,7 @@
 import React, { useRef, useContext, useState, useEffect } from 'react';
 import { ErrorContext } from "../../../context/ErrorContext.jsx";
 import styles from './ProfilePhoto.module.scss';
+import LazyImage from "../../LazyImage/LazyImage.jsx";
 
 export const ProfilePhoto = ({ person, setPerson }) => {
     const { setError } = useContext(ErrorContext);
@@ -12,13 +13,10 @@ export const ProfilePhoto = ({ person, setPerson }) => {
     useEffect(() => {
         const getImage = async () => {
             if (typeof person.avatar === 'string') {
-                // If avatar is a URL string
                 setImageSrc(person.avatar);
             } else if (!person.avatar) {
-                // If avatar is empty or undefined
                 setImageSrc('https://placehold.co/400x400?text=Фото');
             } else if (!person.avatar.type.startsWith('image/')) {
-                // If the file is not an image
                 setError('Файл должен быть изображением.');
                 setImageSrc('https://placehold.co/400x400?text=Фото');
             } else {
@@ -64,7 +62,7 @@ export const ProfilePhoto = ({ person, setPerson }) => {
                 onClick={() => fileInputRef.current.click()}
             >
                 <div className={styles.ProfilePhotoContainer}>
-                    <img src={imageSrc} alt="Profile Preview" />
+                    <LazyImage src={imageSrc} alt="Profile Preview" />
                     <div
                         className={`${styles.ProfilePhotoContainerChange} ${styles.slideInBottom}`}
                     >

--- a/react-chat/src/components/EditableFields/ProfilePhoto/ProfilePhoto.module.scss
+++ b/react-chat/src/components/EditableFields/ProfilePhoto/ProfilePhoto.module.scss
@@ -22,7 +22,7 @@
       opacity: 1;
     }
 
-    img {
+    &Img {
       width: 100%;
       height: 100%;
       border-radius: 50%;

--- a/react-chat/src/components/LazyImage/LazyImage.jsx
+++ b/react-chat/src/components/LazyImage/LazyImage.jsx
@@ -1,0 +1,52 @@
+import React, {useEffect, useState} from 'react';
+import useIntersectionObserver from '../../hooks/useIntersectionObserver';
+import styles from './LazyImage.module.scss';
+
+const LazyImage = ({ src, alt, placeholder, errorPlaceholder, className, ...props }) => {
+    const [ref, isVisible] = useIntersectionObserver({
+        threshold: 0.1,
+    });
+
+    const [isLoaded, setIsLoaded] = useState(false);
+    const [hasError, setHasError] = useState(false);
+
+
+    useEffect(() => {
+        console.log({isLoaded, src, alt});
+    }, [isLoaded]);
+
+    const handleLoad = () => {
+        setIsLoaded(true);
+    };
+
+    const handleError = () => {
+        setHasError(true);
+    };
+
+    return (
+        <div className={`${className? className: ''}`} ref={ref}>
+            {!isLoaded && !hasError && (
+                <div className={`${className? className: ''} ${styles.placeholder}`}>
+                    {placeholder || <span className={styles.loader}></span> }
+                </div>
+            )}
+            {hasError && (
+                <div className={styles.error}>
+                    {errorPlaceholder || 'Ошибка загрузки'}
+                </div>
+            )}
+            {isVisible && !hasError && (
+                <img
+                    src={src}
+                    alt={alt}
+                    onLoad={handleLoad}
+                    onError={handleError}
+                    className={`${className? className: ''} ${!isLoaded && styles.hidden}`}
+                    {...props}
+                />
+            )}
+        </div>
+    );
+};
+
+export default LazyImage;

--- a/react-chat/src/components/LazyImage/LazyImage.module.scss
+++ b/react-chat/src/components/LazyImage/LazyImage.module.scss
@@ -1,0 +1,49 @@
+/* src/components/LazyImage/LazyImage.module.scss */
+.imageWrapper {
+  position: relative;
+  height: auto;
+  width: 100%;
+  overflow: hidden;
+}
+
+.placeholder{
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.error {
+  background-color: #ffe6e6;
+  color: #cc0000;
+}
+
+.image {
+  height: auto;
+  width: 100%;
+  display: block;
+  transition: opacity 0.3s ease-in-out;
+}
+
+.hidden {
+  opacity: 0;
+}
+
+.loader {
+  width: 48px;
+  height: 48px;
+  border: 5px solid #FFF;
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  display: inline-block;
+  box-sizing: border-box;
+  animation: rotation 1s linear infinite;
+}
+
+@keyframes rotation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/react-chat/src/components/MessageItem/MessageItem.jsx
+++ b/react-chat/src/components/MessageItem/MessageItem.jsx
@@ -9,6 +9,7 @@ import { GeoPreview } from '../GeoPreview/GeoPreview.jsx';
 import { AudioPlayer } from '../AudioPlayer/AudioPlayer.jsx';
 import { getFormattedDate, getFormattedTime } from "../../utils/datetime.js";
 import {MessageItemContextMenu} from "../MessageItemContextMenu/MessageItemContextMenu.jsx";
+import LazyImage from "../LazyImage/LazyImage.jsx";
 
 export const MessageItem = memo(
     forwardRef(({ message, isFound = false, currentAudio, setCurrentAudio, onMessageDelete, onMessageEdit }, ref) => {
@@ -78,7 +79,7 @@ export const MessageItem = memo(
             >
                 {message.files && message.files.length > 0 && (
                     <div className={styles.messageItemImage}>
-                        <img src={message.files[0].item} alt="image" />
+                        <LazyImage className={styles.messageItemImageImg} src={message.files[0].item} alt="image" />
                     </div>
                 )}
 

--- a/react-chat/src/components/MessageItem/MessageItem.module.scss
+++ b/react-chat/src/components/MessageItem/MessageItem.module.scss
@@ -70,8 +70,9 @@
     margin-bottom: 10px;
     @include mixins.flex-center();
 
-    & > img {
+    &Img {
       //width: 100%;
+      object-fit: cover;
       max-height: 300px;
     }
   }

--- a/react-chat/src/components/Modals/ChatInfoModal/ChatInfoModal.jsx
+++ b/react-chat/src/components/Modals/ChatInfoModal/ChatInfoModal.jsx
@@ -2,6 +2,7 @@ import classes from './ChatInfoModal.module.scss'
 import React from "react";
 import {imgOrPlaceholder} from "../../../utils/imgOrPlaceholder/imgOrPlaceholder.js";
 import {ChatMembers} from "../../ChatMembers/ChatMembers.jsx";
+import LazyImage from "../../LazyImage/LazyImage.jsx";
 
 export const ChatInfoModal = ({onClose, currentChat}) => {
 
@@ -13,7 +14,7 @@ export const ChatInfoModal = ({onClose, currentChat}) => {
                 <span className={classes.EditChatModalCloseButton} onClick={onClose}>&times;</span>
                 {currentChat && <h1 className={classes.EditChatName}>{currentChat.title}</h1>}
                 <div className={classes.EditChatPhotoContainer}>
-                    {currentChat && <img src={chatAvatarSrc} alt={currentChat.title} className={classes.EditChatPhoto}/>}
+                    {currentChat && <LazyImage src={chatAvatarSrc} alt={currentChat.title} className={classes.EditChatPhoto}/>}
                 </div>
                 <h1 >Участники</h1>
                 <ChatMembers members={currentChat.members}/>

--- a/react-chat/src/hooks/useIntersectionObserver.js
+++ b/react-chat/src/hooks/useIntersectionObserver.js
@@ -1,0 +1,33 @@
+import { useEffect, useRef, useState } from 'react';
+
+const useIntersectionObserver = (options) => {
+    const [isIntersecting, setIsIntersecting] = useState(false);
+    const elementRef = useRef(null);
+
+    useEffect(() => {
+        const observer = new IntersectionObserver(
+            ([entry]) => {
+                if (entry.isIntersecting) {
+                    setIsIntersecting(true);
+                    observer.unobserve(entry.target);
+                }
+            },
+            options
+        );
+
+        const currentElement = elementRef.current;
+        if (currentElement) {
+            observer.observe(currentElement);
+        }
+
+        return () => {
+            if (currentElement) {
+                observer.unobserve(currentElement);
+            }
+        };
+    }, [options]);
+
+    return [elementRef, isIntersecting];
+};
+
+export default useIntersectionObserver;

--- a/simple-chat/src/components/chatWindow/chatWindow.js
+++ b/simple-chat/src/components/chatWindow/chatWindow.js
@@ -45,7 +45,7 @@ function fillHeader(chatId) {
 
         const receiverNameSpan = `<span class="receiver-name white">${person.name}</span>`;
 
-        const receiverPhotoDiv = `<div class="receiver-photo"><img 
+        const receiverPhotoDiv = `<div class="receiver-photo"><LazyImage 
             class="receiver-photo__image" 
             src="${person.photo}" 
             width="50px" 


### PR DESCRIPTION
# Домашнее задание №11

Прошу @martinkomitsky, @haseprogram, @kgrechin или @Ivan-Bir проверить его.

Что было сделано:
* Добавлен LazyImage, поиграл немного с оптимизациями

# Анализ производительности
## Lighthouse
![image](https://github.com/user-attachments/assets/68210d36-d0e8-4f47-b4e0-526dd792a18a)
Проблемы выявленные в данном отчете:
- Можно поиграть с размерами изображений
- Есть смещения контента при загрузке контента происходит из-за того, что сначала отрисовывается страница, потом при ее отрисовке запрашивается список чатов

## Снепшот памяти
![image](https://github.com/user-attachments/assets/3ed16f11-f8a6-4f19-b946-49cefcd39409)

Объем сильно вырос после использования приложения
- Однако судя по разнице, больше всего вырос compiled code

![image](https://github.com/user-attachments/assets/3fece753-1566-4546-a8cd-7de6b3a0bb04)
- На втором месте: строки с информацией с био пользователей 
![image](https://github.com/user-attachments/assets/804fb22e-800a-4304-bd42-9bfaaea596f1)

Эти строки приходят из описаний чатов, где есть участники. Тут происходит лично у меня дилема. С одной стороны хранить их нету смысла всегда, с другой же поскольку они все равно приходят с апи, лучше хранить и если пользователь захочет посмотреть список участников, то он уже будет готов, что предотвратит лишний поход в сеть и приложение будет казаться быстрее.

- В остальном, больше ничего сильно не выбивается 

